### PR TITLE
feat: gather & pass along metas to .wav - EXPERIMENTAL

### DIFF
--- a/src/renderer/smf.h
+++ b/src/renderer/smf.h
@@ -78,6 +78,9 @@ struct SMF_Data
     SMF_Header header;
     std::vector<uint8_t> bytes;
     std::vector<SMF_Track> tracks;
+    std::vector<std::string> textEvents;
+    std::vector<std::string> trackNames;
+    std::vector<std::string> copyrights;
 };
 
 const size_t SMF_CHANNEL_COUNT = 16;

--- a/src/renderer/wav.h
+++ b/src/renderer/wav.h
@@ -8,6 +8,13 @@
 #include <cstdio>
 #include <filesystem>
 
+struct WavMetadata {
+    std::string title;      // INAM
+    std::string artist;     // IART
+    std::string copyright;  // ICOP
+    std::string comment;    // ICMT
+};
+
 class WAV_Handle
 {
 public:
@@ -29,7 +36,7 @@ public:
     void Write(const AudioFrame<int16_t>& frame);
     void Write(const AudioFrame<int32_t>& frame);
     void Write(const AudioFrame<float>& frame);
-    void Finish();
+    void Finish(const WavMetadata &meta);
 
 private:
     FILE*       m_output = nullptr;


### PR DESCRIPTION
### FOR SHORT-TERM POSTERITY ONLY; __NOT__ A PULL REQUEST

This is mostly a failed (ok - _learning_) experiment, as the metadata was found to be too unpredictable to be useful. 😏

Current alternate plan:
- Extract the set of meta tags & values (i.e., for  `eventTypeText`, `eventTypeCopyright`, `eventTypeTrackName` and maybe `eventTypeMarker`) using a separate program (e.g. such as [`mzb`'s `reader`](https://github.com/noodnik2/mzb/blob/a40e5b751909d58725cfc356f8c7fca6b793fd8a/go/cmd/reader/main.go#L13))
- Pass this metadata as key/value pairs to an AI LLM along with an effective query prompt asking it to determine the correct values for `title`, `author`, `copyright` and `comment` with some specified degree of confidence
- When it returns useful values for these items, use `exiftool` (or other) to update the metadata in the (previously) rendered file(s) (e.g., having already been created using the [create-m4a-album.sh](https://github.com/noodnik2/Nuked-SC55/blob/acaed5e8165dc285ee0f6ebfbd60d1ec31ad189b/scripts/create-m4a-album.sh#L1) script).

Initial exploration of this idea has given reason for optimism; indeed it's able to make great inferences about these values from the metadata I've given in prompts to standard models in a handful of examples.